### PR TITLE
CLOUD-487 create uluwatu cluster when stack creation was successful

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -81,7 +81,7 @@ cloudbreakApp.config([ '$routeProvider', '$locationProvider', function($routePro
             var block = false
             if (config.url.match(/^(.*)templates($|\/).*/) || config.url.match(/^(.*)blueprints($|\/).*/)
             || config.url.match(/^(.*)credentials($|\/).*/) || config.url.match(/^(.*)users($|\?).*/)
-            || config.url.match(/^(.*)permission($|\?).*/) || config.url.match(/^stacks\/(\d+)\/cluster($|\/).*/)
+            || config.url.match(/^(.*)permission($|\?).*/) || config.url.match(/^stacks(\/(\d+)\/cluster($|\/).*)?/)
             || config.url.match(/^periscope\/clusters($|\/).*/) || config.url.match(/^(.*)usages($|\?).*/)){
                 block = true
             }

--- a/app/static/js/controllers/clusterController.js
+++ b/app/static/js/controllers/clusterController.js
@@ -113,15 +113,21 @@ angular.module('uluwatuControllers').controller('clusterController', ['$scope', 
                   item.templateId = parseFloat(item.templateId);
                 });
                 result.blueprintId = parseFloat(result.blueprintId);
-                $rootScope.clusters.push(result);
-                initCluster();
-                $jq('.carousel').carousel(0);
-                // enable toolbar buttons
-                $jq('#toggle-cluster-block-btn').removeClass('disabled');
-                $jq('#sort-clusters-btn').removeClass('disabled');
-                $jq('#create-cluster-btn').removeClass('disabled');
-                $jq("#notification-n-filtering").prop("disabled", false);
-                $scope.clusterCreationForm.$setPristine();
+
+                var existingCluster = $filter('filter')($rootScope.clusters, {id: result.id}, true)[0];
+                if (existingCluster != undefined) {
+                    existingCluster = result;
+                } else {
+                    $rootScope.clusters.push(result);
+                    $jq('.carousel').carousel(0);
+                    // enable toolbar buttons
+                    $jq('#toggle-cluster-block-btn').removeClass('disabled');
+                    $jq('#sort-clusters-btn').removeClass('disabled');
+                    $jq('#create-cluster-btn').removeClass('disabled');
+                    $jq("#notification-n-filtering").prop("disabled", false);
+                    $scope.clusterCreationForm.$setPristine();
+                    initCluster();
+                }
             }, function(failure) {
                 $scope.showError(failure, $rootScope.error_msg.cluster_failed);
             });

--- a/app/static/js/services.js
+++ b/app/static/js/services.js
@@ -199,6 +199,7 @@ uluwatuServices.factory('UluwatuCluster', ['StackValidation', 'UserStack', 'Acco
                         emailNeeded: cluster.email,
                         hostGroups: cluster.hostGroups
                     }
+                    successHandler(cluster);
                     Cluster.save({ id: result.id }, cbCluster, function (result) {
                         cluster.hoursUp = 0;
                         cluster.minutesUp = 0;


### PR DESCRIPTION
@doktoric or @oleewere 

The pull is intended to solve issue that occurs when notification arrives before the cluster creation has been finished and it could not be added to the appropriate cluster's event list.